### PR TITLE
解决 H5+ app端  swipe-action 的滑动问题

### DIFF
--- a/packages/uni-swipe-action/uni-swipe-action.vue
+++ b/packages/uni-swipe-action/uni-swipe-action.vue
@@ -124,6 +124,9 @@ export default {
       }
     },
     touchStart (event) {
+      if(!this.btnGroupWidth){
+			  this.getSize()
+		  }
       this.startTime = event.timeStamp
       this.startX = event.touches[0].pageX
       this.startY = event.touches[0].pageY


### PR DESCRIPTION
解决 H5+ app端 uni.createSelectorQuery() API 首次加载时&& swipe-action隐藏状态下，获取不到 页面元素信息（宽度、高度）的问题 
bug描述：【加载app端 页面隐藏状态的 swipe-action -> list-item  组件时， uni.createSelectorQuery()无法获取页面第一个list-item的元素信息】