### PR TITLE
uni-combox组件数据类型兼容问题

### DIFF
--- a/src/components/uni-combox/uni-combox.vue
+++ b/src/components/uni-combox/uni-combox.vue
@@ -63,7 +63,7 @@
 				default: '无匹配项'
 			},
 			value: {
-				type: String,
+				type: [String, Number],
 				default: ''
 			}
 		},
@@ -84,7 +84,7 @@
 			},
 			filterCandidates() {
 				return this.candidates.filter((item) => {
-					return item.indexOf(this.inputVal) > -1
+					return item.toString().indexOf(this.inputVal) > -1
 				})
 			},
 			filterCandidatesLength() {


### PR DESCRIPTION
uni-combox组件增加数据类型兼容，传入参数（数组）带纯数字选项时，因没有indexOf而方法产生报错！

1. indexOf查找时toString避免报错
2. 传入数据类型增加Number避免v-model报错
3. 数字||字符串组成的数组其实可正常使用即可