### PR TITLE
修复swipe-action-item支付宝下高度不适应的bug

### DIFF
--- a/src/components/uni-swipe-action-item/mpalipay.js
+++ b/src/components/uni-swipe-action-item/mpalipay.js
@@ -4,6 +4,7 @@ export default {
 			isshow: false,
 			viewWidth: 0,
 			buttonWidth: 0,
+			movableHeight: 0,
 			disabledView: false,
 			x: 0,
 			transition: false
@@ -135,7 +136,8 @@ export default {
 
 		},
 		getQuerySelect() {
-			const query = uni.createSelectorQuery().in(this);
+			const query = uni.createSelectorQuery().in(this)
+			const contentBox = uni.createSelectorQuery().in(this)
 			query.selectAll('.viewWidth-hook').boundingClientRect(data => {
 
 				this.viewWidth = data[0].width
@@ -143,6 +145,9 @@ export default {
 				this.transition = false
 				this.$nextTick(() => {
 					this.transition = true
+					contentBox.select('.movable-view-box').boundingClientRect(res => {
+						this.movableHeight = res.height
+					}).exec()
 				})
 
 				if (!this.buttonWidth) {

--- a/src/components/uni-swipe-action-item/uni-swipe-action-item copy.vue
+++ b/src/components/uni-swipe-action-item/uni-swipe-action-item copy.vue
@@ -59,8 +59,8 @@
 		<!-- #ifdef MP-ALIPAY -->
 		<view class="uni-swipe-box" @touchstart="touchstart" @touchmove="touchmove" @touchend="touchend">
 			<view class="viewWidth-hook">
-				<movable-area v-if="viewWidth !== 0" class="movable-area" :style="{width:(viewWidth-buttonWidth)+'px'}">
-					<movable-view class="movable-view" direction="horizontal" :animation="!transition" :style="{width:viewWidth+'px'}"
+				<movable-area class="movable-area" :style="{width:(viewWidth-buttonWidth)+'px', height: movableHeight + 'px'}">
+					<movable-view class="movable-view" direction="horizontal" :animation="!transition" :style="{width:viewWidth+'px', height: movableHeight + 'px'}"
 					 :class="[transition?'transition':'']" :x="x" :disabled="disabledView" @change="onChange">
 						<view class="movable-view-box">
 							<slot></slot>
@@ -247,14 +247,11 @@
 	/* #ifdef MP-ALIPAY */
 	.movable-area {
 		width: 300px;
-		height: 100%;
-		height: 45px;
 	}
 
 	.movable-view {
 		position: relative;
 		width: 160%;
-		height: 45px;
 		z-index: 2;
 	}
 	.transition {
@@ -263,7 +260,6 @@
 
 	.movable-view-box {
 		width: 100%;
-		height: 100%;
 		background-color: #fff;
 	}
 	/* #endif */


### PR DESCRIPTION
当前支付宝使用movable-view来实现该组件，由于组件的高度被设置为45px，这导致支付宝下swipe-action-item的高度无法根据内容自适应，从而显示不全。

针对支付宝新增了动态计算swipe-action-item内容高度的逻辑，使其高度按照内容自适应