### PR TITLE
fix: 修复倒计时异步修改时间戳无效和当不显示天数时小时显示错误

### DIFF
--- a/src/components/uni-countdown/readme.md
+++ b/src/components/uni-countdown/readme.md
@@ -19,7 +19,9 @@ export default {
 ```html
 <!-- 一般用法 -->
 <uni-countdown :day="1" :hour="1" :minute="12" :second="40"></uni-countdown>
-<uni-countdown :timestamp="90732"></uni-countdown>
+
+<!-- 使用时间戳 -->
+<uni-countdown :timestamp="parseInt(new Date().getTime() / 1000) + 90732"></uni-countdown>
 
 <!-- 不显示天数 -->
 <uni-countdown :show-day="false" :hour="12" :minute="12" :second="12"></uni-countdown>
@@ -39,7 +41,7 @@ export default {
 |hour				|Number	|0		|小时				|
 |minute				|Number	|0		|分钟				|
 |second				|Number	|0		|秒					|
-|timestamp          |Number |0      |时间戳，单位为秒   |
+|timestamp          |Number |0      |结束时间的时间戳，单位为秒 |
 |showDay			|Boolean|true	|是否显示天数		|
 |showColon			|Boolean|true	|是否以冒号为分隔符	|
 

--- a/src/components/uni-countdown/readme.md
+++ b/src/components/uni-countdown/readme.md
@@ -5,7 +5,7 @@
 
 ### 使用方式
 
-在 ``script`` 中引用组件 
+在 ``script`` 中引用组件
 
 ```javascript
 import uniCountdown from "@/components/uni-countdown/uni-countdown.vue"
@@ -19,6 +19,7 @@ export default {
 ```html
 <!-- 一般用法 -->
 <uni-countdown :day="1" :hour="1" :minute="12" :second="40"></uni-countdown>
+<uni-countdown :timestamp="90732"></uni-countdown>
 
 <!-- 不显示天数 -->
 <uni-countdown :show-day="false" :hour="12" :minute="12" :second="12"></uni-countdown>
@@ -38,6 +39,7 @@ export default {
 |hour				|Number	|0		|小时				|
 |minute				|Number	|0		|分钟				|
 |second				|Number	|0		|秒					|
+|timestamp          |Number |0      |时间戳，单位为秒   |
 |showDay			|Boolean|true	|是否显示天数		|
 |showColon			|Boolean|true	|是否以冒号为分隔符	|
 

--- a/src/components/uni-countdown/uni-countdown.vue
+++ b/src/components/uni-countdown/uni-countdown.vue
@@ -100,6 +100,9 @@
 			},
 			second(val) {
 				this.changeFlag()
+			},
+			timestamp(val) {
+				this.changeFlag()
 			}
 		},
 		created: function(e) {

--- a/src/components/uni-countdown/uni-countdown.vue
+++ b/src/components/uni-countdown/uni-countdown.vue
@@ -126,7 +126,7 @@
 				let seconds = this.seconds
 				let [day, hour, minute, second] = [0, 0, 0, 0]
 				if (seconds > 0) {
-					day = Math.floor(seconds / (60 * 60 * 24))
+					day = this.showDay ? Math.floor(seconds / (60 * 60 * 24)) : 0
 					hour = Math.floor(seconds / (60 * 60)) - (day * 24)
 					minute = Math.floor(seconds / 60) - (day * 24 * 60) - (hour * 60)
 					second = Math.floor(seconds) - (day * 24 * 60 * 60) - (hour * 60 * 60) - (minute * 60)


### PR DESCRIPTION
- 修复异步修改 `timestamp` 不能开启倒计时
- 修改当配置 `:show-day="false"` 时，将天数转移到小时上
- 更新倒计时的文档