### PR TITLE
修复form表单和数字输入框bug

### DIFF
--- a/packages/lib/uni-forms/uni-forms.vue
+++ b/packages/lib/uni-forms/uni-forms.vue
@@ -138,7 +138,9 @@
 					this.formRules = formRules
 					if (!this.validator) {
 						this.validator = new Validator(formRules)
-					}
+					} else {
+            this.validator.updateSchema(formRules)
+          }
 				}
 				this.childrens.forEach((item) => {
 					item.init()

--- a/packages/lib/uni-number-box/uni-number-box.vue
+++ b/packages/lib/uni-number-box/uni-number-box.vue
@@ -58,7 +58,7 @@
 			},
 			inputValue(newVal, oldVal) {
 				if (+newVal !== +oldVal) {
-					this.$emit("change", newVal);
+					this.$emit("change", +newVal);
 				}
 			}
 		},


### PR DESCRIPTION
1、form组建的rules变化时，没有同时更新validator的schema，导致可能会验证不存在的字段而报错。
2、数字输入框组件change事件的参数为字符串，与组件内部值不一致。

其他改动点：文件内部换行符混用，被github自动格式化为Windows风格换行符