### PR TITLE
docs: Update rate doc with the correct demo url

### DIFF
--- a/docs/components/rate.md
+++ b/docs/components/rate.md
@@ -1,5 +1,5 @@
 ---
-url : pages/vue/popup/popup
+url : pages/vue/rate/rate
 ---
 
 ## Rate 评分


### PR DESCRIPTION
纠正了在Rate评分的doc页面默认加载popup的demo