### PR TITLE
修复 uni-data-pickerview 的bug

### DIFF
--- a/packages/lib/uni-data-pickerview/uni-data-pickerview.vue
+++ b/packages/lib/uni-data-pickerview/uni-data-pickerview.vue
@@ -97,7 +97,8 @@
 					this.selected.splice(i, this.selected.length - i)
 					this.selected.push(node)
 				} else if (i === this.selected.length - 1) {
-					this.selected[i] = node
+					// this.selected[i] = node
+					this.$set(this.selected, i, node)
 				}
 
 				if (node.isleaf) {


### PR DESCRIPTION
`uni-data-pickerview` 中的 `selected` 数组属性变化没有被 vue 监听，导致使用该组件遇到省市区级联选择等场景时无法实现。