### PR TITLE
fix: uni-easyinput 组件，只在获取焦点时展示清除图标

### DIFF
--- a/uni_modules/uni-easyinput/components/uni-easyinput/uni-easyinput.vue
+++ b/uni_modules/uni-easyinput/components/uni-easyinput/uni-easyinput.vue
@@ -23,7 +23,7 @@
 			</template>
 			<template v-else>
 				<uni-icons class="content-clear-icon" :class="{'is-textarea-icon':type==='textarea'}" type="clear" :size="clearSize"
-				 v-if="clearable && val " color="#c0c4cc" @click="onClear"></uni-icons>
+				 v-if="clearable && focused && val" color="#c0c4cc" @click="onClear"></uni-icons>
 			</template>
 			<slot name="right"></slot>
 		</view>
@@ -244,10 +244,11 @@
 			},
 
 			onFocus(event) {
-				// this.focused = true;
+				this.focused = true;
 				this.$emit('focus', event);
 			},
 			onBlur(event) {
+				this.focused = false;
 				let value = event.detail.value;
 				// setTimeout(() => {
 				// this.focused = false;

--- a/uni_modules/uni-easyinput/components/uni-easyinput/uni-easyinput.vue
+++ b/uni_modules/uni-easyinput/components/uni-easyinput/uni-easyinput.vue
@@ -248,11 +248,10 @@
 				this.$emit('focus', event);
 			},
 			onBlur(event) {
-				this.focused = false;
+				setTimeout(() => {
+					this.focused = false;
+				}, 100);
 				let value = event.detail.value;
-				// setTimeout(() => {
-				// this.focused = false;
-				// }, 100);
 				this.$emit('blur', event);
 			},
 			onConfirm(e) {


### PR DESCRIPTION
插件市场最新的版本【0.0.12（2021-05-12）】，默认会展示清除图标，
如果表单中有多个输入，就会导致同时存在多个清除图标。


<img width="322" alt="默认不应展示清除图标" src="https://user-images.githubusercontent.com/12031430/119963002-2e919280-bfda-11eb-8908-b990cb7deebe.png">
