### PR TITLE
update:使uni-th的width支持rpx格式，且兼容老版本

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -107,7 +107,7 @@ selection-change	| 开启多选时，当选择项发生变化时会触发该事�
 
 |属性名		|类型		|默认值	 	|可选值				|说明|
 |:-:			|:-:		|:-:			|	:-:				|:-:|
-|width		|String	| -				|-					| 单元格宽度|
+|width		|String	| -				|-					| 单元格宽度。支持纯数字（px）、或携带单位px、rpx|
 |align		|String	| left		|left/center/right	| 表头对齐方式|
 |filter-type		|String	| 	|search/select/range/date	| 筛选类型，search关键字搜索，select类别选择|
 |filter-data		|Array	| 	|| 筛选数据|

--- a/uni_modules/uni-table/components/uni-th/uni-th.vue
+++ b/uni_modules/uni-table/components/uni-th/uni-th.vue
@@ -1,6 +1,6 @@
 <template>
 	<!-- #ifdef H5 -->
-	<th :rowspan="rowspan" :colspan="colspan" class="uni-table-th" :class="{ 'table--border': border }" :style="{ width: width + 'px', 'text-align': align }">
+	<th :rowspan="rowspan" :colspan="colspan" class="uni-table-th" :class="{ 'table--border': border }" :style="{ width: customWidth + 'px', 'text-align': align }">
 		<view class="uni-table-th-row">
 			<view class="uni-table-th-content" :style="{ 'justify-content': contentAlign }" @click="sort">
 				<slot></slot>
@@ -14,7 +14,7 @@
 	</th>
 	<!-- #endif -->
 	<!-- #ifndef H5 -->
-	<view class="uni-table-th" :class="{ 'table--border': border }" :style="{ width: width + 'px', 'text-align': align }"><slot></slot></view>
+	<view class="uni-table-th" :class="{ 'table--border': border }" :style="{ width: customWidth + 'px', 'text-align': align }"><slot></slot></view>
 	<!-- #endif -->
 </template>
 
@@ -24,7 +24,7 @@
  * Th 表头
  * @description 表格内的表头单元格组件
  * @tutorial https://ext.dcloud.net.cn/plugin?id=3270
- * @property {Number} 	width 						单元格宽度
+ * @property {Number | String} 	width 	单元格宽度（支持纯数字、携带单位px或rpx）
  * @property {Boolean} 	sortable 					是否启用排序
  * @property {Number} 	align = [left|center|right]	单元格对齐方式
  * @value left   	单元格文字左侧对齐
@@ -85,6 +85,29 @@ export default {
 		}
 	},
 	computed: {
+		// 根据props中的width属性 自动匹配当前th的宽度(px)
+		customWidth(){
+			if(typeof this.width === 'number'){
+				return this.width
+			} else if(typeof this.width === 'string') {
+				let regexHaveUnitPx = new RegExp(/^[1-9][0-9]*px$/g)
+				let regexHaveUnitRpx = new RegExp(/^[1-9][0-9]*rpx$/g)
+				let regexHaveNotUnit = new RegExp(/^[1-9][0-9]*$/g)
+				if (this.width.match(regexHaveUnitPx) !== null) { // 携带了 px
+					return this.width.replace('px', '')
+				} else if (this.width.match(regexHaveUnitRpx) !== null) { // 携带了 rpx
+					let numberRpx = Number(this.width.replace('rpx', ''))
+					let widthCoe = uni.getSystemInfoSync().screenWidth / 750
+					return Math.round(numberRpx * widthCoe)
+				} else if (this.width.match(regexHaveNotUnit) !== null) { // 未携带 rpx或px 的纯数字 String
+					return this.width
+				} else { // 不符合格式
+					return ''
+				}
+			} else {
+				return ''
+			}
+		},
 		contentAlign() {
 			let align = 'left'
 			switch (this.align) {
@@ -104,7 +127,7 @@ export default {
 	created() {
 		this.root = this.getTable('uniTable')
 		this.rootTr = this.getTable('uniTr')
-		this.rootTr.minWidthUpdate(this.width ? this.width : 140)
+		this.rootTr.minWidthUpdate(this.customWidth ? this.customWidth : 140)
 		this.border = this.root.border
 		this.root.thChildren.push(this)
 	},

--- a/uni_modules/uni-table/readme.md
+++ b/uni_modules/uni-table/readme.md
@@ -105,7 +105,7 @@ selection-change	| 开启多选时，当选择项发生变化时会触发该事�
 
 |属性名		|类型		|默认值	 	|可选值				|说明|
 |:-:			|:-:		|:-:			|	:-:				|:-:|
-|width		|String	| -				|-					| 单元格宽度。支持纯数字（px）、或携带单位px、rpx|
+|width		|String	| -				|-					| 单元格宽度|
 |align		|String	| left		|left/center/right	| 表头对齐方式|
 |filter-type		|String	| 	|search/select/range/date	| 筛选类型，search关键字搜索，select类别选择|
 |filter-data		|Array	| 	|| 筛选数据|


### PR DESCRIPTION
优化了uni-th组件的width值传递方式。现在可以传入携带rpx或者px单位的值了，且兼容了之前的传入方式。如果依然传入数字，还是以px方式。如果传入rpx，会按照手机屏幕宽度来计算它的px值。

因为表格组件的层层嵌套，暂时没做到真正在css里使用rpx，但是也一定程度上解决了很多项目中会使用rpx的需求。

去真正的让宽度变为rpx的话，涉及到多个组件的方法修改，改动到非常多的组件，我可能会尝试在以后来实现。
