### PR TITLE
uni-forms-item左侧插槽有left改为label

### DIFF
--- a/uni_modules/uni-forms/components/uni-forms-item/uni-forms-item.vue
+++ b/uni_modules/uni-forms/components/uni-forms-item/uni-forms-item.vue
@@ -3,7 +3,7 @@
 		<view class="uni-forms-item__box">
 			<view class="uni-forms-item__inner" :class="['is-direction-' + labelPos]">
 				<view class="uni-forms-item__label" :style="{ width: labelWid , justifyContent: justifyContent }">
-					<slot name="left">
+					<slot name="label">
 						<text v-if="required" class="is-required">*</text>
 						<uni-icons v-if="leftIcon" class="label-icon" size="16" :type="leftIcon" :color="iconColor" />
 						<text class="label-text">{{ label }}</text>


### PR DESCRIPTION
根据文档说明left(已经失效，请使用label代替)，查看源码后发现依然是
`<slot name="left">`
因此改为
`<slot name="label">`
文档参考地址：[uni-forms](https://uniapp.dcloud.io/component/uniui/uni-forms?id=formsitem-slots)