### PR TITLE
修复card里thumbnail不显示

### DIFF
--- a/uni_modules/uni-card/components/uni-card/uni-card.vue
+++ b/uni_modules/uni-card/components/uni-card/uni-card.vue
@@ -184,6 +184,7 @@
 				.uni-card__header-avatar-image {
 					flex: 1;
 					width: 40px;
+					height: 100%;
 				}
 			}
 


### PR DESCRIPTION
如果给card组件一个thumbnail的话,由于原来的<image>没有指明高度,导致高度变成宽的6位,变成40px*240px,图片的容器是40px*40px,overflow为hidden,图片是水平居中,所以显示不出来.
修改后
```css
.uni-card__header-avatar {
		width: 40px;
		height: 40px;
		overflow: hidden;
		border-radius: 5px;
		margin-right: $uni-card-spacing;
		.uni-card__header-avatar-image {
			flex: 1;
			width: 40px;	
			height: 100%;
		}
	}
}
```
指定`.uni-card__header-avatar-image`为容器高度