### PR TITLE
nvue下avatarCircle圆角头像无效

### DIFF
--- a/uni_modules/uni-list/components/uni-list-chat/uni-list-chat.vue
+++ b/uni_modules/uni-list/components/uni-list-chat/uni-list-chat.vue
@@ -7,7 +7,7 @@
 			<view class="uni-list-chat__container">
 				<view class="uni-list-chat__header-warp">
 					<view v-if="avatarCircle || avatarList.length === 0" class="uni-list-chat__header" :class="{ 'header--circle': avatarCircle }">
-						<image class="uni-list-chat__header-image" :src="avatar" mode="aspectFill"></image>
+						<image class="uni-list-chat__header-image" :class="{ 'header--circle': avatarCircle }" :src="avatar" mode="aspectFill"></image>
 					</view>
 					<!-- 头像组 -->
 					<view v-else class="uni-list-chat__header">


### PR DESCRIPTION
测试vue3下，nvue页面，不能正常显示圆角 ，社区有overflow: hidden;失效相关提问不知是否相关。
暂通过给image添加header--circle解决