### PR TITLE
fix uni-indexed-list 点击列表项事件e.itemIndex不正确问题

### DIFF
--- a/uni_modules/uni-indexed-list/components/uni-indexed-list/uni-indexed-list.vue
+++ b/uni_modules/uni-indexed-list/components/uni-indexed-list/uni-indexed-list.vue
@@ -140,7 +140,7 @@
 			setList() {
 				let index = 0;
 				this.lists = []
-				this.options.forEach((value, index) => {
+				this.options.forEach((value) => {
 					if (value.data.length === 0) {
 						return
 					}


### PR DESCRIPTION
此问题影响点击列表项查找原数据对应的数据项