### PR TITLE
给pop组件添加 onceRender 属性来避免重新渲染Pop组件导致的页面卡顿问题

### DIFF
--- a/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
+++ b/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
@@ -1,5 +1,5 @@
 <template>
-	<view v-if="showPopup" class="uni-popup" :class="[popupstyle, isDesktop ? 'fixforpc-z-index' : '']">
+	<view v-if="showPopup||onceRender" v-show="showPopup"  class="uni-popup" :class="[popupstyle, isDesktop ? 'fixforpc-z-index' : '']">
 		<view @touchstart="touchstart">
 			<uni-transition key="1" v-if="maskShow" name="mask" mode-class="fade" :styles="maskClass"
 				:duration="duration" :show="showTrans" @click="onTap" />
@@ -85,6 +85,11 @@
 			maskBackgroundColor: {
 				type: String,
 				default: 'rgba(0, 0, 0, 0.4)'
+			},
+			// 指定使用v-show指令，不重新渲染Pop组件
+			onceRender:{
+				type:Boolean,
+				default:false
 			},
 		},
 

--- a/uni_modules/uni-transition/components/uni-transition/uni-transition.vue
+++ b/uni_modules/uni-transition/components/uni-transition/uni-transition.vue
@@ -1,5 +1,5 @@
 <template>
-	<view v-if="isShow" ref="ani" :animation="animationData" :class="customClass" :style="transformStyles" @click="onClick"><slot></slot></view>
+	<view v-if="isShow||onceRender" v-show="isShow" ref="ani" :animation="animationData" :class="customClass" :style="transformStyles" @click="onClick"><slot></slot></view>
 </template>
 
 <script>
@@ -48,7 +48,11 @@ export default {
 		customClass:{
 			type: String,
 			default: ''
-		}
+		},
+		onceRender:{
+			type:Boolean,
+			default:false
+		},
 	},
 	data() {
 		return {


### PR DESCRIPTION
给 popup 和transition 组件添加了一个 onceRender 属性, 该属性可以指定组件使用 v-show 切换来避免多次渲染在复杂弹出组件下的卡顿问题, 不破坏当前组件的任何功能, 
如果组件内数据不需要频繁更新就可以使用 once-render 来避免重复渲染, 大幅提升复杂场景下的组件性能问题