### PR TITLE
fix: vue3-time-picker modelValue

### DIFF
--- a/uni_modules/uni-datetime-picker/components/uni-datetime-picker/time-picker.vue
+++ b/uni_modules/uni-datetime-picker/components/uni-datetime-picker/time-picker.vue
@@ -197,6 +197,20 @@
 				},
 				immediate: true
 			},
+      		// #ifdef VUE3
+      		modelValue: {
+				handler(newVal, oldVal) {
+					if (newVal) {
+						this.parseValue(this.fixIosDateFormat(newVal)) //兼容 iOS、safari 日期格式
+						this.initTime(false)
+					} else {
+						this.time = ''
+						this.parseValue(Date.now())
+					}
+				},
+				immediate: true
+			},
+      		// #endif
 			type: {
 				handler(newValue) {
 					if (newValue === 'date') {
@@ -736,7 +750,10 @@
 			 */
 			initTimePicker() {
 				if (this.disabled) return
-				const value = this.fixIosDateFormat(this.value)
+				let value = this.fixIosDateFormat(this.value)
+        		// #ifdef VUE3
+        		value = this.fixIosDateFormat(this.modelValue)
+        		// #endif
 				this.initPickerValue(value)
 				this.visible = !this.visible
 			},


### PR DESCRIPTION


问题：打开日期选择器后，时间空白。再次修改后，时间为当前时间。

![image](https://user-images.githubusercontent.com/40257198/185590836-205c0b40-b01f-4632-bf52-f1bd9d472a67.png)

https://ext.dcloud.net.cn/plugin?name=uni-datetime-picker