### PR TITLE
fix(uni-easyinput): background color is hardcode and can't be changed

### DIFF
--- a/uni_modules/uni-easyinput/components/uni-easyinput/uni-easyinput.vue
+++ b/uni_modules/uni-easyinput/components/uni-easyinput/uni-easyinput.vue
@@ -182,6 +182,7 @@
 				default () {
 					return {
 						color: '#333',
+						backgroundColor: '#fff',
 						disableColor: '#F7F6F6',
 						borderColor: '#e5e5e5'
 					}
@@ -247,7 +248,7 @@
 				const borderColor = this.inputBorder && this.msg ? '#dd524d' : focusColor
 				return obj2strStyle({
 					'border-color': borderColor || '#e5e5e5',
-					'background-color': this.disabled ? this.styles.disableColor : '#fff'
+					'background-color': this.disabled ? this.styles.disableColor : this.styles.backgroundColor
 				})
 			},
 			// input右侧样式


### PR DESCRIPTION
Normal in v1.4.15. There was an unsolvable white background when I updated to v1.4.20.

<img width="749" alt="white background appears" src="https://user-images.githubusercontent.com/41267951/189889277-ea1b1024-2947-4b83-858e-e4c6d532ee9d.png">
