### PR TITLE
fix: 修复uni-popup在支付宝小程序获取底部安全区域错误

### DIFF
--- a/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
+++ b/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
@@ -197,10 +197,13 @@
 				// TODO fix by mehaotian 是否适配底部安全区 ,目前微信ios 、和 app ios 计算有差异，需要框架修复
 				if (safeArea && this.safeArea) {
 					// #ifdef MP-WEIXIN
-					this.safeAreaInsets = screenHeight - safeArea.bottom
+					this.safeAreaInsets = screenHeight - safeArea.bottom;
 					// #endif
-					// #ifndef MP-WEIXIN
-					this.safeAreaInsets = safeAreaInsets.bottom
+					// #ifdef MP-ALIPAY
+					this.safeAreaInsets = safeArea.bottom;
+					// #endif
+					// #ifndef MP-WEIXIN || MP-ALIPAY
+					this.safeAreaInsets = safeAreaInsets.bottom;
 					// #endif
 				} else {
 					this.safeAreaInsets = 0


### PR DESCRIPTION
支付宝小程序中safeArea.bottom即底部安全区域的值，和微信小程序相反，当前代码在支付宝小程序中底部内边距的数值不正确，对此进行了底部安全区域字段调整
![image](https://user-images.githubusercontent.com/76048920/201567426-68b129e5-c4c4-4e2a-9720-1cdbc589a527.png)
![image](https://user-images.githubusercontent.com/76048920/201568189-990d2bd9-4068-4933-b24f-7c73435666cd.png)
