### PR TITLE
fix: 修复uni-popup在支付宝小程序开发者工具获取安全区域显示错误

### DIFF
--- a/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
+++ b/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
@@ -202,6 +202,13 @@
 					// #ifndef MP-WEIXIN
 					this.safeAreaInsets = safeAreaInsets.bottom
 					// #endif
+					// TODO 支付宝小程序在开发者工具中safeArea和safeAreaInsets返回的坐标值相反，添加该判断便于调试，需要框架修复后删除
+					// #ifdef MP-ALIPAY
+					// 判断是否开发者工具
+					if (my.isIDE) {
+						this.safeAreaInsets = safeArea.bottom
+					}
+					// #endif
 				} else {
 					this.safeAreaInsets = 0
 				}


### PR DESCRIPTION
由于支付宝小程序框架目前存在支付宝小程序在开发者工具中safeArea和safeAreaInsets返回的坐标值相反的问题，添加了一个判断便于开发者进行调试，该问题已反馈给支付宝小程序社区，待框架修复后再删除该判断