### PR TITLE
fix: 优化uni-combox组件在选项滚动时将选项框收起问题

### DIFF
--- a/uni_modules/uni-combox/components/uni-combox/uni-combox.vue
+++ b/uni_modules/uni-combox/components/uni-combox/uni-combox.vue
@@ -4,24 +4,26 @@
 			<text>{{label}}</text>
 		</view>
 		<view class="uni-combox__input-box">
-			<input class="uni-combox__input" type="text" :placeholder="placeholder" 
-			placeholder-class="uni-combox__input-plac" v-model="inputVal" @input="onInput" @focus="onFocus" 
+			<input class="uni-combox__input" type="text" :placeholder="placeholder"
+			placeholder-class="uni-combox__input-plac" v-model="inputVal" @input="onInput" @focus="onFocus"
 @blur="onBlur" />
 			<uni-icons :type="showSelector? 'top' : 'bottom'" size="14" color="#999" @click="toggleSelector">
 			</uni-icons>
 		</view>
 		<view class="uni-combox__selector" v-if="showSelector">
 			<view class="uni-popper__arrow"></view>
-			<scroll-view scroll-y="true" class="uni-combox__selector-scroll">
+			<scroll-view scroll-y="true" class="uni-combox__selector-scroll" @scroll="onScroll">
 				<view class="uni-combox__selector-empty" v-if="filterCandidatesLength === 0">
 					<text>{{emptyTips}}</text>
 				</view>
-				<view class="uni-combox__selector-item" v-for="(item,index) in filterCandidates" :key="index" 
+				<view class="uni-combox__selector-item" v-for="(item,index) in filterCandidates" :key="index"
 				@click="onSelectorClick(index)">
 					<text>{{item}}</text>
 				</view>
 			</scroll-view>
 		</view>
+		<!-- 新增蒙层，点击蒙层时关闭选项显示 -->
+		<view class="mask" v-show="showSelector" @click="showSelector = false"></view>
 	</view>
 </template>
 
@@ -83,7 +85,8 @@
 		data() {
 			return {
 				showSelector: false,
-				inputVal: ''
+				inputVal: '',
+				blurTimer:null,
 			}
 		},
 		computed: {
@@ -128,9 +131,15 @@
 				this.showSelector = true
 			},
 			onBlur() {
-				setTimeout(() => {
+				this.blurTimer = setTimeout(() => {
 					this.showSelector = false
 				}, 153)
+			},
+			onScroll(){ // 滚动时将blur的定时器关掉
+				if(this.blurTimer) {
+					clearTimeout(this.blurTimer)
+					this.blurTimer = null
+				}
 			},
 			onSelectorClick(index) {
 				this.inputVal = this.filterCandidates[index]
@@ -205,7 +214,7 @@
 		border: 1px solid #EBEEF5;
 		border-radius: 6px;
 		box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
-		z-index: 2;
+		z-index: 3;
 		padding: 4px 0;
 	}
 
@@ -271,5 +280,14 @@
 
 	.uni-combox__no-border {
 		border: none;
+	}
+
+	.mask {
+		width:100%;
+		height:100%;
+		position: fixed;
+		top: 0;
+		left: 0;
+		// background-color: pink;
 	}
 </style>


### PR DESCRIPTION
问题：在微信小程序上使用uni-combox组件时发现滚动选项时会将选项框隐藏。

原因：input框在blur时会启动后一个定时器将showSelector置为false，导致选项框隐藏。在滚动选项时恰好触发了blur事件。

解决: 监听scroll-view的scroll事件，将blur的定时器清除。新增一个蒙层，点击蒙层时可收起选项框。