### PR TITLE
fix(uni-combox):蒙层类名规范化并设置堆叠层级

### DIFF
--- a/uni_modules/uni-combox/components/uni-combox/uni-combox.vue
+++ b/uni_modules/uni-combox/components/uni-combox/uni-combox.vue
@@ -21,7 +21,7 @@
 			</scroll-view>
 		</view>
 		<!-- 新增蒙层，点击蒙层时关闭选项显示 -->
-		<view class="mask" v-show="showSelector" @click="showSelector = false"></view>
+		<view class="uni-combox__mask" v-show="showSelector" @click="showSelector = false"></view>
 	</view>
 </template>
 
@@ -283,11 +283,12 @@
 		border: none;
 	}
 
-	.mask {
+	.uni-combox__mask {
 		width:100%;
 		height:100%;
 		position: fixed;
 		top: 0;
 		left: 0;
+    z-index: 1;
 	}
 </style>


### PR DESCRIPTION
因样式没有scoped，类名需添加前缀。设置堆叠层级，使得蒙层覆盖页面。