### PR TITLE
fix(uni-status-bar): 修复自定义状态栏高度闪动问题

### DIFF
--- a/uni_modules/uni-nav-bar/components/uni-nav-bar/uni-status-bar.vue
+++ b/uni_modules/uni-nav-bar/components/uni-nav-bar/uni-status-bar.vue
@@ -9,11 +9,8 @@
 		name: 'UniStatusBar',
 		data() {
 			return {
-				statusBarHeight: 20
+				statusBarHeight: uni.getSystemInfoSync().statusBarHeight + 'px'
 			}
-		},
-		mounted() {
-			this.statusBarHeight = uni.getSystemInfoSync().statusBarHeight + 'px'
 		}
 	}
 </script>


### PR DESCRIPTION
之前的默认高度没加px不生效，而且在mounted中获取高度会导致组件高度有一个变化的过程，在小程序端进入页面时会导致整个页面闪动，非常影响体验

https://user-images.githubusercontent.com/52436248/215699792-4f349070-675b-44a4-a384-8e2bec629e4a.mp4

修改后

https://user-images.githubusercontent.com/52436248/215700375-5f4b24f9-c704-475e-ad2f-0a947e6bc7c8.mp4


