### PR TITLE
fix(uni-file-picker):手动上传删除一个文件后不能再上传的bug

### DIFF
--- a/uni_modules/uni-file-picker/components/uni-file-picker/uni-file-picker.vue
+++ b/uni_modules/uni-file-picker/components/uni-file-picker/uni-file-picker.vue
@@ -583,7 +583,11 @@
 						path: v.path,
 						size: v.size,
 						fileID:v.fileID,
-						url: v.url
+						url: v.url,
+						// 修改删除一个文件后不能再上传的bug, #694
+            uuid: v.uuid,
+            status: v.status,
+            cloudPath: v.cloudPath
 					})
 				})
 				return newFilesData


### PR DESCRIPTION
fix #694
这个bug同时会影响（ 前提是手动上传，autoUpload: flase ）

1.上传成功后直接上传或对现有图片再增删再手动上传会错误
2.设置v-model回显，再添加图片，上传异常

另外官网上标明如果要设置回显，v-model最起码要绑定以下三个属性，[链接](https://uniapp.dcloud.net.cn/component/uniui/uni-file-picker.html#value-%E6%A0%BC%E5%BC%8F)
```
"name":"file.txt",
"extname":"txt",
"url":"https://xxxx",
```
这样回显是没问题，如果回显直接点击上传，或再添加几张图片上传，就会有问题，
此时还要绑定以下属性才有效果
```
image: { width, height },
uuid: Date.now(),
status: 'ready',
progress: 0,
fileType: 'image',
cloudPath: `${Date.now()}_${index}.${extname}`
```
