### PR TITLE
fix(uni-calendar):修复日历头部picker选择年月时未触发monthSwitch事件的BUG及更新文档

### DIFF
--- a/uni_modules/uni-calendar/components/uni-calendar/uni-calendar.vue
+++ b/uni_modules/uni-calendar/components/uni-calendar/uni-calendar.vue
@@ -217,8 +217,12 @@
 			clean() {},
 			bindDateChange(e) {
 				const value = e.detail.value + '-1'
-				console.log(this.cale.getDate(value));
 				this.setDate(value)
+				let detail = this.cale.getDate(value)
+				this.$emit('monthSwitch', {
+					year: detail.year,
+					month: detail.month
+				})
 			},
 			/**
 			 * 初始化日期显示

--- a/uni_modules/uni-calendar/readme.md
+++ b/uni_modules/uni-calendar/readme.md
@@ -77,7 +77,7 @@ export default {
 ### Calendar Props
 
 |  属性名	|    类型	| 默认值| 说明																													|
-| 		| 																													|
+| -	| -	| - | - |
 | date		| String	|-		| 自定义当前时间，默认为今天																							|
 | lunar		| Boolean	| false	| 显示农历																												|
 | startDate	| String	|-		| 日期选择范围-开始日期																									|
@@ -91,7 +91,7 @@ export default {
 ### Calendar Events
 
 |  事件名		| 说明								|返回值|
-| 								|		| 									|
+| -	|	-	| -	|
 | open	| 弹出日历组件，`insert :false` 时生效|- 	|
 
 


### PR DESCRIPTION
1，修复日历头部picker选择年月时未触发monthSwitch事件的BUG（或者是触发change事件？但感觉既然是选择年月，那么触发monthSwitch更合理一些）
2，原先文档缺少正确md标签，无法正常显示表格，新增标签后使其能正常显示
