### PR TITLE
fix: 修复切换到其他月份，点击返回今日的时候 未触发 monthSwitch 事件

### DIFF
--- a/uni_modules/uni-calendar/components/uni-calendar/uni-calendar.vue
+++ b/uni_modules/uni-calendar/components/uni-calendar/uni-calendar.vue
@@ -217,7 +217,6 @@
 			clean() {},
 			bindDateChange(e) {
 				const value = e.detail.value + '-1'
-				console.log(this.cale.getDate(value));
 				this.setDate(value)
 			},
 			/**
@@ -324,11 +323,12 @@
 			 * 回到今天
 			 */
 			backtoday() {
-				console.log(this.cale.getDate(new Date()).fullDate);
-				let date = this.cale.getDate(new Date()).fullDate
-				// this.cale.setDate(date)
-				this.init(date)
+				let date = this.cale.getDate(new Date())
+				let nowYearMonth = `${this.nowDate.year}-${this.nowDate.month}`
+				let toYearMonth = `${date.year}-${date.month}`
+				this.init(date.fullDate)
 				this.change()
+				nowYearMonth == toYearMonth || this.monthSwitch()
 			},
 			/**
 			 * 上个月


### PR DESCRIPTION
1. 修复当我切换到其他月份，然后再点击 `今日` 放回到当前日期的时候，虽然月份改变了，但是没有触发 `monthSwitch`
2. 删除无用的调试代码