### PR TITLE
fix( uni-datetime-picker): 修复this.$refs.right.next()报错

### DIFF
--- a/uni_modules/uni-datetime-picker/components/uni-datetime-picker/uni-datetime-picker.vue
+++ b/uni_modules/uni-datetime-picker/components/uni-datetime-picker/uni-datetime-picker.vue
@@ -486,8 +486,8 @@
 						this.popover.right = 0
 					}
 				}).exec()
+				this.popup = !this.popup
 				setTimeout(() => {
-					this.popup = !this.popup
 					if (!this.isPhone && this.isRange && this.isFirstShow) {
 						this.isFirstShow = false
 						const {


### PR DESCRIPTION
this.popup = true时，calendar组件还未渲染,this.$refs.right.next会报错