### PR TITLE
:sparkles:feat: feat(uni-countdown): 新增zeroPad参数-是否补0

### DIFF
--- a/uni_modules/uni-countdown/components/uni-countdown/uni-countdown.vue
+++ b/uni_modules/uni-countdown/components/uni-countdown/uni-countdown.vue
@@ -86,6 +86,10 @@
 			timestamp: {
 				type: Number,
 				default: 0
+			},
+      zeroPad: {
+				type: Boolean,
+				default: true
 			}
 		},
 		data() {
@@ -199,18 +203,10 @@
 				} else {
 					this.timeUp()
 				}
-				if (day < 10) {
-					day = '0' + day
-				}
-				if (hour < 10) {
-					hour = '0' + hour
-				}
-				if (minute < 10) {
-					minute = '0' + minute
-				}
-				if (second < 10) {
-					second = '0' + second
-				}
+        day = (day < 10 && this.zeroPad) ? `0${day}` : day
+				hour = (hour < 10 && this.zeroPad) ? `0${hour}` : hour
+				minute = (minute < 10 && this.zeroPad) ? `0${minute}` : minute
+				second = (second < 10 && this.zeroPad) ? `0${second}` : second
 				this.d = day
 				this.h = hour
 				this.i = minute


### PR DESCRIPTION
git diff有点奇怪，多了很多相同地方的diff，我并未开启格式化工具，我想也许是因为行尾换行符导致的

实际上我只改动了以下代码
```js
      zeroPad: {
	  type: Boolean,
	  default: true
       }
```
```js
        day = (day < 10 && this.zeroPad) ? `0${day}` : day
	hour = (hour < 10 && this.zeroPad) ? `0${hour}` : hour
	minute = (minute < 10 && this.zeroPad) ? `0${minute}` : minute
	second = (second < 10 && this.zeroPad) ? `0${second}` : second
```

这个需求来自社区反馈：
> https://ask.dcloud.net.cn/question/155494