### PR TITLE
fix(uni-datetime-picker): 修复日期选择器展示的日期文字与图标对齐

### DIFF
--- a/uni_modules/uni-datetime-picker/components/uni-datetime-picker/calendar.vue
+++ b/uni_modules/uni-datetime-picker/components/uni-datetime-picker/calendar.vue
@@ -725,6 +725,10 @@
 		width: 100px;
 		font-size: 15px;
 		color: #666;
+		height: 50px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	.uni-calendar__button-text {


### PR DESCRIPTION
修复在PC端或平板设备上，日期标题文字与图标不对齐的问题。