### PR TITLE
fix(uni-calendar): 切换到今天时，先触发了monthSwitch，然后设置的日期，导致月份切换的时间是旧日期

### DIFF
--- a/uni_modules/uni-calendar/components/uni-calendar/uni-calendar.vue
+++ b/uni_modules/uni-calendar/components/uni-calendar/uni-calendar.vue
@@ -328,11 +328,12 @@
 				const date = this.cale.getDate(new Date())
         const todayYearMonth = `${date.year}-${date.month}`
 
+				this.init(date.fullDate)
+
         if(nowYearMonth !== todayYearMonth) {
           this.monthSwitch()
         }
 
-				this.init(date.fullDate)
 				this.change()
 			},
 			/**


### PR DESCRIPTION
修改了执行顺序，先执行 this.init，再判断是否执行 this.monthSwitch