### PR TITLE
修复 [plugin:vite:nvue-css] ERROR: property value `left` is not support…

### DIFF
--- a/uni_modules/uni-search-bar/components/uni-search-bar/uni-search-bar.vue
+++ b/uni_modules/uni-search-bar/components/uni-search-bar/uni-search-bar.vue
@@ -242,11 +242,11 @@
 		/* #ifndef APP-NVUE */
 		display: flex;
 		box-sizing: border-box;
+		justify-content: left;
 		/* #endif */
 		overflow: hidden;
 		position: relative;
 		flex: 1;
-		justify-content: left;
 		flex-direction: row;
 		align-items: center;
 		height: $uni-searchbar-height;


### PR DESCRIPTION
…ed for `justify-content` (supported values are: `flex-start`|`flex-end`|`center`|`space-between`|`space-around`)​