### PR TITLE
fix(uni-nav-bar): 修复使用自定义导航栏并开启下拉刷新时 onPullDownRefresh 的 loading 元素被导航栏遮挡的问题

### DIFF
--- a/uni_modules/uni-nav-bar/components/uni-nav-bar/uni-nav-bar.vue
+++ b/uni_modules/uni-nav-bar/components/uni-nav-bar/uni-nav-bar.vue
@@ -318,7 +318,7 @@
 
 	.uni-navbar--fixed {
 		position: fixed;
-		z-index: 998;
+		z-index: 99;
 		/* #ifdef H5 */
 		left: var(--window-left);
 		right: var(--window-right);


### PR DESCRIPTION
修改前
![image](https://github.com/dcloudio/uni-ui/assets/49092777/d603a949-52da-4158-9484-e6bd496aade4)

修改后
![image](https://github.com/dcloudio/uni-ui/assets/49092777/a7264c84-eeeb-47ff-b853-3bc84013a033)
