### PR TITLE
fix:增加showClose参数判断后样式判断

### DIFF
--- a/uni_modules/uni-popup/components/uni-popup-dialog/uni-popup-dialog.vue
+++ b/uni_modules/uni-popup/components/uni-popup-dialog/uni-popup-dialog.vue
@@ -18,7 +18,7 @@
 			<view class="uni-dialog-button" v-if="showClose" @click="closeDialog">
 				<text class="uni-dialog-button-text">{{closeText}}</text>
 			</view>
-			<view class="uni-dialog-button uni-border-left" @click="onOk">
+			<view class="uni-dialog-button" :class="showClose?'uni-border-left':''" @click="onOk">
 				<text class="uni-dialog-button-text uni-button-color">{{okText}}</text>
 			</view>
 		</view>


### PR DESCRIPTION
uni-popup 组件增加 showClose 参数判断后，如果取消按钮不展示了，则两个按钮中间的那个线，应该也不要展示了。
修改后该线的样式也随 参数 showClose 一起判断。