### PR TITLE
bugfix(popup): 修复H5环境下切换页面后overflow:hidden仍然生效的问题

### DIFF
--- a/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
+++ b/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
@@ -220,6 +220,12 @@
 		unmounted() {
 			this.setH5Visible()
 		},
+		activated() {
+   	  this.setH5Visible(!this.showPopup);
+    },
+    deactivated() {
+      this.setH5Visible(true);
+    },
 		// #endif
 		created() {
 			// this.mkclick =  this.isMaskClick || this.maskClick
@@ -240,10 +246,10 @@
 			this.maskClass.backgroundColor = this.maskBackgroundColor
 		},
 		methods: {
-			setH5Visible() {
+			setH5Visible(visible = true) {
 				// #ifdef H5
 				// fix by mehaotian 处理 h5 滚动穿透的问题
-				document.getElementsByTagName('body')[0].style.overflow = 'visible'
+				document.getElementsByTagName('body')[0].style.overflow =  visible ? "visible" : "hidden";
 				// #endif
 			},
 			/**


### PR DESCRIPTION
bug复现步骤
1.打开弹窗，触发了 `overflow:hidden`
2.切换页面，由于`keep-alive`的存在，页面没有被销毁，页面无法滚动