### PR TITLE
fix(uni-search-bar): modelValue is old value when executing clear event

### DIFF
--- a/uni_modules/uni-search-bar/components/uni-search-bar/uni-search-bar.vue
+++ b/uni_modules/uni-search-bar/components/uni-search-bar/uni-search-bar.vue
@@ -177,7 +177,9 @@
 			},
 			clear() {
 				this.searchVal = ""
-				this.$emit("clear", '');
+				this.$nextTick(() => {
+					this.$emit("clear", { value: "" })
+				})
 			},
 			cancel() {
 				if(this.readonly) return


### PR DESCRIPTION
The return value of `@clear` in SearchBar is different from the document. and obtained modelValue is still old value.

<img width="500" alt="240328_fix-uni-search-bar" src="https://github.com/dcloudio/uni-ui/assets/41267951/bffd53dd-9aa6-4d8d-b388-e6f10725f5b5">
