### PR TITLE
fix(uni-data-select): 修复由于选项中文文本过长导致的样式穿透问题

### DIFF
--- a/uni_modules/uni-data-select/components/uni-data-select/uni-data-select.vue
+++ b/uni_modules/uni-data-select/components/uni-data-select/uni-data-select.vue
@@ -404,6 +404,7 @@
 	}
 
 	.uni-select__input-box {
+		width: 100%;
 		height: 35px;
 		position: relative;
 		/* #ifndef APP-NVUE */


### PR DESCRIPTION
修复前：
![image](https://github.com/dcloudio/uni-ui/assets/24959547/b2ee04d6-1c3f-42aa-a12f-4fa9dc550a88)

修复后：
![image](https://github.com/dcloudio/uni-ui/assets/24959547/a63de27d-f59e-437a-ab04-eda0dee0992e)

