### PR TITLE
重置默认值，未能在日历面板展示的默认值未选中状态

### DIFF
--- a/uni_modules/uni-datetime-picker/components/uni-datetime-picker/uni-datetime-picker.vue
+++ b/uni_modules/uni-datetime-picker/components/uni-datetime-picker/uni-datetime-picker.vue
@@ -666,6 +666,7 @@
 						this.displayValue = e.fulldate
 					}
 					this.setEmit(this.displayValue)
+					this.calendarDate = this.displayValue;
 				}
 				this.$refs.mobile.close()
 			},


### PR DESCRIPTION
fixbug: v-model绑定字符串值类型的时候，在日历面板选中其他日期后，通过改变v-model绑定值重置为默认值，但是日历面板选中状态未能选中默认值。