### PR TITLE
修复 toISOString() 引发的时区问题

### DIFF
--- a/uni_modules/uni-table/components/uni-th/filter-dropdown.vue
+++ b/uni_modules/uni-table/components/uni-th/filter-dropdown.vue
@@ -203,7 +203,7 @@
 			},
 			resetDate() {
 				let date = new Date()
-				let dateText = date.toISOString().split('T')[0]
+				let dateText = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
 				this.dateRange = [dateText + ' 0:00:00', dateText + ' 23:59:59']
 			},
 			onDropdown(e) {


### PR DESCRIPTION
中国是东八区，`toISOString()` 获取的是0时区时间。也就是说，在0点到8点，`toISOString().split('T')[0]` 取到的时间是前一天的日期。