### PR TITLE
fix(easyinput): 修复easyinput示例页面插槽名称不正确

### DIFF
--- a/pages/vue/easyinput/easyinput.vue
+++ b/pages/vue/easyinput/easyinput.vue
@@ -29,16 +29,16 @@
 		</uni-section>
 
 
-		<uni-section title="插槽" subTitle="使用 prefixIcon / suffixIcon 插槽 ,可以自定义输入框左右侧内容" type="line" padding>
+		<uni-section title="插槽" subTitle="使用 left / right 插槽 ,可以自定义输入框左右侧内容" type="line" padding>
 			<uni-easyinput v-model="value" placeholder="请输入网址">
-				<template #prefixIcon>
+				<template #left>
 					<view
 						style="background-color: #f2f2f2;padding: 0 10rpx;height: 70rpx;line-height: 70rpx;margin-right: 10rpx;">
 						https://</view>
 				</template>
 			</uni-easyinput>
 			<uni-easyinput class="uni-mt-5" prefixIcon="search" v-model="value" placeholder="想看什么,搜索一下">
-				<template #suffixIcon>
+				<template #right>
 					<button class="uni-btn uni-btn-mini uni-btn-radius" type="primary" size="mini">搜索</button>
 				</template>
 			</uni-easyinput>


### PR DESCRIPTION
1. 插槽名称已变更为left和right插槽，示例页面还是使用的prefixIcon/ suffixIcon 插槽，导致示例页面功能未正常使用，提交了修复希望pr能够合并。
现：
![image](https://github.com/user-attachments/assets/67a4db82-53b6-47be-82f2-b4fe296c756e)
![image](https://github.com/user-attachments/assets/cd0e1d6b-f4ec-495b-b0fe-812849539f91)
pr:
![image](https://github.com/user-attachments/assets/4def2edd-5584-41cd-8cea-810188a6bb17)
![image](https://github.com/user-attachments/assets/200c33b9-0ab0-4567-a274-e1f1b16f82a7)
