### PR TITLE
fix: uni-popup-dialog 监听器未兼容modelValue的问题修正

### DIFF
--- a/uni_modules/uni-popup/components/uni-popup-dialog/uni-popup-dialog.vue
+++ b/uni_modules/uni-popup/components/uni-popup-dialog/uni-popup-dialog.vue
@@ -155,13 +155,16 @@
 					this.dialogType = 'info'
 				}
 			},
+			// #ifdef VUE2
 			value(val) {
-				if (this.maxlength != -1 && this.mode === 'input') {
-					this.val = val.slice(0, this.maxlength);
-				} else {
-					this.val = val
-				}
+				this.setVal(val)
 			},
+			// #endif
+			// #ifdef VUE3
+			modelValue(val) {
+				this.setVal(val)
+			},
+			// #endif
 			val(val) {
 				// #ifdef VUE2
 				// TODO 兼容 vue2
@@ -207,6 +210,16 @@
 				this.$emit('close')
 				if (this.beforeClose) return
 				this.popup.close()
+			},
+			/**
+			 * 设置val的值
+			 */
+			setVal(val) {
+				if (this.maxlength != -1 && this.mode === 'input') {
+					this.val = val.slice(0, this.maxlength);
+				} else {
+					this.val = val
+				}
 			},
 			close() {
 				this.popup.close()

--- a/uni_modules/uni-popup/package.json
+++ b/uni_modules/uni-popup/package.json
@@ -1,7 +1,7 @@
 {
 	"id": "uni-popup",
 	"displayName": "uni-popup 弹出层",
-	"version": "1.9.1",
+	"version": "1.9.2",
 	"description": " Popup 组件，提供常用的弹层",
 	"keywords": [
         "uni-ui",


### PR DESCRIPTION
最新版本，在created生命周期中做了value和modelValue的兼容：
```js
created() {
	// 对话框遮罩不可点击
	this.popup.disableMask()
	// this.popup.closeMask()
	if (this.mode === 'input') {
		this.dialogType = 'info'
		this.val = this.value;
		// #ifdef VUE3
		this.val = this.modelValue;
		// #endif
	} else {
		this.dialogType = this.type
	}
}
```
但是watch中只有对value属性的监听器，因此在vue3的版本中，由于缺少modelValue监听器，使用v-model可能导致双向绑定失效。
修复vue2和Vue3设置对应的监听器：
```js
// #ifdef VUE2
value(val) {
this.setVal(val)
},
// #endif
// #ifdef VUE3
modelValue(val) {
this.setVal(val)
}

/**
* 设置val的值
*/
setVal(val) {
if (this.maxlength != -1 && this.mode === 'input') {
	this.val = val.slice(0, this.maxlength);
} else {
	this.val = val
}
}
```