### PR TITLE
fix: 去掉了calendar.js中toChinaDay方法的多余的break

### DIFF
--- a/uni_modules/uni-calendar/components/uni-calendar/calendar.js
+++ b/uni_modules/uni-calendar/components/uni-calendar/calendar.js
@@ -351,10 +351,8 @@ var calendar = {
         s = '\u521d\u5341'; break
       case 20:
         s = '\u4e8c\u5341'; break
-        break
       case 30:
         s = '\u4e09\u5341'; break
-        break
       default :
         s = this.nStr2[Math.floor(d / 10)]
         s += this.nStr1[d % 10]


### PR DESCRIPTION
今天在使用uni-calendar的时候审阅calendar.js的代码时候突然发现，4年前居然还有2个多余的break没删干净。🤣🤣🤣🤣
https://github.com/dcloudio/uni-ui/blob/7fa0c0f35a63021b2dd5db0a01691f37c2b6c2eb/uni_modules/uni-calendar/components/uni-calendar/calendar.js#L354
https://github.com/dcloudio/uni-ui/blob/7fa0c0f35a63021b2dd5db0a01691f37c2b6c2eb/uni_modules/uni-calendar/components/uni-calendar/calendar.js#L357
