### PR TITLE
Update uni-data-select.vue

### DIFF
--- a/uni_modules/uni-data-select/components/uni-data-select/uni-data-select.vue
+++ b/uni_modules/uni-data-select/components/uni-data-select/uni-data-select.vue
@@ -20,9 +20,18 @@
 						<view class="uni-select__selector-empty" v-if="mixinDatacomResData.length === 0">
 							<text>{{emptyTips}}</text>
 						</view>
-						<view v-else class="uni-select__selector-item" v-for="(item,index) in mixinDatacomResData" :key="index"
-							@click="change(item)">
-							<text :class="{'uni-select__selector__disabled': item.disable}">{{formatItemName(item)}}</text>
+						<view
+								v-else
+								class="uni-select__selector-item"
+								:class="{ 'uni-select_selector-item_active': item[dataKey] == current }"
+								style="display: flex; justify-content: space-between; align-items: center"
+								v-for="(item, index) in mixinDatacomResData"
+								:key="index"
+								@click="change(item)">
+								<text :class="{ 'uni-select__selector__disabled': item.disable }">{{
+										formatItemName(item)
+								}}</text>
+								<uni-icons v-if="item[dataKey] == current" type="checkmarkempty" color="#007aff" />
 						</view>
 					</scroll-view>
 				</view>
@@ -569,5 +578,11 @@
 		right: 0;
 		left: 0;
 		z-index: 2;
+	}
+
+	.uni-select_selector-item_active {
+	    color: #409eff;
+	    font-weight: bold;
+	    background-color: #f5f7fa;
 	}
 </style>


### PR DESCRIPTION
1、新增property：dataKey、dataValue，让数据格式更灵活，从固定的[{text:'',value:''}]形式改为可通过dataKey、dataValue自定义，比如[{name:'',value:''}]
2、对于选中项，进行高亮提示

![image](https://github.com/user-attachments/assets/c3dbf6f0-4027-4bdd-96e7-e359ca9bcd62)


![image](https://github.com/user-attachments/assets/8d945132-c2d7-494c-b4e5-ce968175777a)
