### PR TITLE
fix: 修复H5跳转后前一个页面设置body overflow:hidden导致无法滑动的问题

### DIFF
--- a/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
+++ b/uni_modules/uni-popup/components/uni-popup/uni-popup.vue
@@ -130,12 +130,16 @@
 			showPopup(show) {
 				// #ifdef H5
 				// fix by mehaotian 处理 h5 滚动穿透的问题
+				if (!this.isActive) {
+					return
+				}
 				document.getElementsByTagName('body')[0].style.overflow = show ? 'hidden' : 'visible'
 				// #endif
 			}
 		},
 		data() {
 			return {
+				isActive: true,
 				duration: 300,
 				ani: [],
 				showPopup: false,
@@ -237,21 +241,25 @@
 		// #ifndef VUE3
 		// TODO vue2
 		destroyed() {
+			this.isActive = false;
 			this.setH5Visible()
 		},
 		// #endif
 		// #ifdef VUE3
 		// TODO vue3
 		unmounted() {
+			this.isActive = false;
 			this.setH5Visible()
 		},
 		// #endif
 		activated() {
-   	  this.setH5Visible(!this.showPopup);
-    },
-    deactivated() {
-      this.setH5Visible(true);
-    },
+			this.isActive = true;
+   	  		this.setH5Visible(!this.showPopup);
+		},
+		deactivated() {
+			this.isActive = false;
+			this.setH5Visible(true);
+		},
 		created() {
 			// this.mkclick =  this.isMaskClick || this.maskClick
 			if (this.isMaskClick === null && this.maskClick === null) {


### PR DESCRIPTION
当A页面内有异步操作，在异步操作完成前，页面进行了跳转B页面。这时在A页面异步操作完成后调用open会导致下一个页面无法滚动。

本次提交在设置前在生命周期做了判断，防止误操作。